### PR TITLE
[Metal] Fix OPCODE_MOD for floats

### DIFF
--- a/sources/backends/metal.c
+++ b/sources/backends/metal.c
@@ -674,6 +674,12 @@ static void write_functions(char *code, size_t *offset) {
 				}
 				break;
 			}
+			case OPCODE_MOD: {
+				indent(code, offset, &indentation);
+				*offset += sprintf(&code[*offset], "%s _%" PRIu64 " = fmod(_%" PRIu64 ", _%" PRIu64 ");\n", type_string(o->op_binary.result.type.type),
+				                   o->op_binary.result.index, o->op_binary.left.index, o->op_binary.right.index);
+				break;
+			}
 			default:
 				cstyle_write_opcode(code, offset, o, type_string, &indentation);
 				break;

--- a/sources/backends/metal.c
+++ b/sources/backends/metal.c
@@ -675,7 +675,7 @@ static void write_functions(char *code, size_t *offset) {
 				break;
 			}
 			case OPCODE_MOD: {
-				indent(code, offset, &indentation);
+				indent(code, offset, indentation);
 				*offset += sprintf(&code[*offset], "%s _%" PRIu64 " = fmod(_%" PRIu64 ", _%" PRIu64 ");\n", type_string(o->op_binary.result.type.type),
 				                   o->op_binary.result.index, o->op_binary.left.index, o->op_binary.right.index);
 				break;


### PR DESCRIPTION
In HLSL the `%` also handles floats. This enables to do that in Metal as well. For integers the behaviour should remain the same.

HLSL also has `fmod` funtion, which appears to be [slightly different](https://stackoverflow.com/questions/13050981/is-fmod-equivalient-to-the-operator-in-hlsl) compared to the `%`. 