### PR TITLE
Fix TRANSFORM_FLAG_BINARY_UNIFY_LENGTH for SPIR-V

### DIFF
--- a/sources/transformer.c
+++ b/sources/transformer.c
@@ -205,13 +205,13 @@ void transform(uint32_t flags) {
 							init_type_ref(&t, NO_NAME);
 							t.type = vector_to_size(left_type, right_size);
 
-							vec = allocate_variable(t, o->op_binary.left.kind);
+							vec = allocate_variable(t, VARIABLE_INTERNAL);
 
 							opcode constructor_call = {
 							    .type = OPCODE_CALL,
 							    .op_call =
 							        {
-							            .func            = get_type(o->op_load_access_list.to.type.type)->name,
+							            .func            = get_type(right_type)->name,
 							            .parameters_size = right_size,
 							            .var             = vec,
 							        },
@@ -282,13 +282,13 @@ void transform(uint32_t flags) {
 							init_type_ref(&t, NO_NAME);
 							t.type = vector_to_size(left_type, left_size);
 
-							vec = allocate_variable(t, o->op_binary.right.kind);
+							vec = allocate_variable(t, VARIABLE_INTERNAL);
 
 							opcode constructor_call = {
 							    .type = OPCODE_CALL,
 							    .op_call =
 							        {
-							            .func            = get_type(o->op_load_access_list.to.type.type)->name,
+							            .func            = get_type(left_type)->name,
 							            .parameters_size = left_size,
 							            .var             = vec,
 							        },


### PR DESCRIPTION
This fixes

`OpLoad Pointer <id> '73[%73]' is not a logical pointer.` error when doing:

```
var a: float3 = float3(1.0, 1.0, 1.0);
var b: float = 2.0;
var c: float3 = a * b;
```

`VARIABLE_INTERNAL` prevents [get_var](https://github.com/Kode/Kongruent/blob/9115dcb159d8c7ff1d7a4066b0bbcdafa5576560/sources/backends/spirv.c#L1645) from emitting `op_load` for the intermediary float3(b, b, b) vector.