### PR TITLE
[SPIR-V] Fix write_string

### DIFF
--- a/sources/backends/spirv.c
+++ b/sources/backends/spirv.c
@@ -447,7 +447,7 @@ static spirv_id allocate_index(void) {
 static uint16_t write_string(uint32_t *operands, const char *string) {
 	uint16_t length = (uint16_t)strlen(string);
 	uint16_t word_count = (length + 1) / 4 + 1;
-	memset(&operands[0], 0, word_count * sizeof(uint32_t));
+	operands[word_count - 1] = 0;
 	memcpy(&operands[0], string, length + 1);
 	return word_count;
 }

--- a/sources/backends/spirv.c
+++ b/sources/backends/spirv.c
@@ -446,8 +446,10 @@ static spirv_id allocate_index(void) {
 
 static uint16_t write_string(uint32_t *operands, const char *string) {
 	uint16_t length = (uint16_t)strlen(string);
+	uint16_t word_count = (length + 1) / 4 + 1;
+	memset(&operands[0], 0, word_count * sizeof(uint32_t));
 	memcpy(&operands[0], string, length + 1);
-	return (length + 1) / 4 + 1;
+	return word_count;
 }
 
 static spirv_id write_op_ext_inst_import(instructions_buffer *instructions, const char *name) {


### PR DESCRIPTION
This was not causing any issues on desktop nor `spirv-val`, but the adreno gpu found in my android device refused to compile the shader without any meaningful error message apart from "pipeline compile failed".

When inspecting the spirv binary, the entry point named "main" had "450" garbage data appended to it, likely from the previous string write of "GLSL.std.450"? Now the whole string buffer is zeroed out first.